### PR TITLE
fix the stratum-proxy README

### DIFF
--- a/docs/participate/stratum-proxy/run-stratum.md
+++ b/docs/participate/stratum-proxy/run-stratum.md
@@ -123,7 +123,7 @@ Within the `config.json` file, you'll be able to configure networking settings a
 Before running the proxy, we need to build the source. You can build via Makefile by running the following command:
 
 ```bash
-make quai-stratum
+make go-quai-stratum
 ```
 
 ### Run
@@ -135,13 +135,13 @@ To run the proxy, you'll need to select a shard to run against. More information
 Start the proxy by passing either the corresponding **web socket ports** or **chain names** for the region and zone you've selected to run. Run with chain names using this command:
 
 ```bash
-./build/bin/quai-stratum --region=REGION-NAME --zone=ZONE-NAME
+./build/bin/go-quai-stratum --region=REGION-NAME --zone=ZONE-NAME
 ```
 
 Or to run with ports use:
 
 ```sh
-./build/bin/quai-stratum --region=REGION-WS-PORT --zone=ZONE-WS-PORT
+./build/bin/go-quai-stratum --region=REGION-WS-PORT --zone=ZONE-WS-PORT
 ```
 
 :::warning

--- a/docs/participate/stratum-proxy/stratum-faq.md
+++ b/docs/participate/stratum-proxy/stratum-faq.md
@@ -40,7 +40,7 @@ Yes. In order for your GPU miner to be able to use the stratum proxy to connect 
 
 ```bash
 # REGION-WS-PORT and ZONE-WS-PORT should be replaced with the correct ports.
-./build/bin/quai-stratum --region=REGION-WS-PORT --zone=ZONE-WS-PORT
+./build/bin/go-quai-stratum --region=REGION-WS-PORT --zone=ZONE-WS-PORT
 ```
 
 To properly run this command, you'll need to replace `REGION-WS-PORT` and `ZONE-WS-PORT` with the correct ports for the slice you wish the proxy to run.
@@ -52,15 +52,15 @@ To find the correct WS ports, you can either check the [Run a Stratum Proxy](/pa
 | Cyprus     | Region |             | 8579            |                                                         |
 | Paxos      | Region |             | 8581            |                                                         |
 | Hydra      | Region |             | 8583            |                                                         |
-| Cyprus-1   | Zone   | [0 0]       | 8611            | ./build/bin/quai-stratum --region=cyprus --zone=cyprus1 |
-| Cyprus-2   | Zone   | [0 1]       | 8643            | ./build/bin/quai-stratum --region=cyprus --zone=cyprus2 |
-| Cyprus-3   | Zone   | [0 2]       | 8675            | ./build/bin/quai-stratum --region=cyprus --zone=cyprus3 |
-| Paxos-1    | Zone   | [1 0]       | 8613            | ./build/bin/quai-stratum --region=paxos --zone=paxos1   |
-| Paxos-2    | Zone   | [1 1]       | 8645            | ./build/bin/quai-stratum --region=paxos --zone=paxos2   |
-| Paxos-3    | Zone   | [1 2]       | 8677            | ./build/bin/quai-stratum --region=paxos --zone=paxos3   |
-| Hydra-1    | Zone   | [2 0]       | 8615            | ./build/bin/quai-stratum --region=hydra --zone=hydra1   |
-| Hydra-2    | Zone   | [2 1]       | 8647            | ./build/bin/quai-stratum --region=hydra --zone=hydra2   |
-| Hydra-3    | Zone   | [2 2]       | 8679            | ./build/bin/quai-stratum --region=hydra --zone=hydra3   |
+| Cyprus-1   | Zone   | [0 0]       | 8611            | ./build/bin/go-quai-stratum --region=cyprus --zone=cyprus1 |
+| Cyprus-2   | Zone   | [0 1]       | 8643            | ./build/bin/go-quai-stratum --region=cyprus --zone=cyprus2 |
+| Cyprus-3   | Zone   | [0 2]       | 8675            | ./build/bin/go-quai-stratum --region=cyprus --zone=cyprus3 |
+| Paxos-1    | Zone   | [1 0]       | 8613            | ./build/bin/go-quai-stratum --region=paxos --zone=paxos1   |
+| Paxos-2    | Zone   | [1 1]       | 8645            | ./build/bin/go-quai-stratum --region=paxos --zone=paxos2   |
+| Paxos-3    | Zone   | [1 2]       | 8677            | ./build/bin/go-quai-stratum --region=paxos --zone=paxos3   |
+| Hydra-1    | Zone   | [2 0]       | 8615            | ./build/bin/go-quai-stratum --region=hydra --zone=hydra1   |
+| Hydra-2    | Zone   | [2 1]       | 8647            | ./build/bin/go-quai-stratum --region=hydra --zone=hydra2   |
+| Hydra-3    | Zone   | [2 2]       | 8679            | ./build/bin/go-quai-stratum --region=hydra --zone=hydra3   |
 
 ## Advanced Setup
 


### PR DESCRIPTION
the makefile had changed from v0.12, but the readme without change.
And in the readme has an example with v0.9.0-rc.0, i leave it as it is.

![Screenshot from 2024-01-26 11-47-53](https://github.com/dominant-strategies/quai-docs/assets/80843905/f7e4d52f-dae7-4ebd-be83-440d85ed4571)
