### PR TITLE
Update gpu-miner-faq.md

### DIFF
--- a/docs/participate/mining/gpu-miner/gpu-miner-faq.md
+++ b/docs/participate/mining/gpu-miner/gpu-miner-faq.md
@@ -152,7 +152,7 @@ This flight sheet was created and is maintained by a Quai community member, not 
 ![Flight Sheets](/img/FS4.jpg)
 
 8. On "Miner name", type "quai_custom".
-9. On "Installation URL", copy/paste "[https://quai-gpu-releases.s3.eu-west-1.amazonaws.com/quai_custom-0.3.2.tar.gz](https://quai-gpu-releases.s3.eu-west-1.amazonaws.com/quai_custom-0.3.2.tar.gz)".
+9. On "Installation URL", copy/paste "[https://quai-gpu-releases.s3.eu-west-1.amazonaws.com/quai_custom-0.3.3.tar.gz](https://quai-gpu-releases.s3.eu-west-1.amazonaws.com/quai_custom-0.3.3.amd.tar.gz)".
 10. On "Hash algorithm", type "progpow".
 11. On "Wallet and worker template", type "%WAL%.%WORKER_NAME%".
 12. On "Pool URL", type "stratum://EXTERNALIPADDRESS:PORT".


### PR DESCRIPTION
[Installation URL](https://quai-gpu-releases.s3.eu-west-1.amazonaws.com/quai_custom-0.3.2.tar.gz) miner version has changed from 0.3.2 to 0.3.3.
![SharedScreenshot](https://github.com/dominant-strategies/quai-docs/assets/98585161/51a4fddb-d209-4a1a-9b98-fa022aacdc83)
Here is the correct URL: https://quai-gpu-releases.s3.eu-west-1.amazonaws.com/quai_custom-0.3.3.amd.tar.gz