### PR TITLE
Devnet chainid

### DIFF
--- a/build/networks.mdx
+++ b/build/networks.mdx
@@ -6,13 +6,13 @@ description: Specifications for Quai development and testing environments.
 ## Devnet
 
 <Tip>
-  The public developer network is currently running the **Golden Age Testnet** version of the Quai Protocol, compatible with [quais v1.0.0-alpha.6](https://www.npmjs.com/package/quais/v/1.0.0-alpha.6) and later.
+  The public developer network is currently running the **Golden Age Testnet** version of the Quai Protocol, compatible with [quais v1.0.0-alpha.8](https://www.npmjs.com/package/quais/v/1.0.0-alpha.8) and later.
 
 This network is designed for developers to test features prior to the official release of the Golden Age Testnet and **has no incentives**.
 
 </Tip>
 
-Devnet is a public isolated development environment that is designed to be used by both smart contract and tooling developers to test smart-contract deployments and infrastructure upgrades in a production-like environment.
+Devnet is a public isolated development environment that is designed to be used by both smart contract and tooling developers to test smart-contract deployments and infrastructure upgrades in a production-like environment. Developers looking to test can easily mint devnet QUAI from the [devnet faucet](https://faucet.quai.network).
 
 QUAI on the devnet has no real value and thus testing deployments, interactions, and smart contracts are virtually free. As devnet QUAI has no value, there are _no markets_ to purchase devnet tokens.
 
@@ -25,45 +25,47 @@ QUAI on the devnet has no real value and thus testing deployments, interactions,
 		title='Chain ID'
 		icon='link'
 	>
-		12000
+		9000
+	</Card>
+	<Card
+		title='Faucet'
+		href='https://faucet.quai.network'
+		icon='faucet'
+	>
+		Devnet Faucet
 	</Card>
 </CardGroup>
 
 #### Explorer URLs and RPC Endpoints
 
-| Zone Name | Zone Index | Explorer URL | RPC Endpoint (http)                   | RPC Endpoint (Websocket)           |
-| --------- | ---------- | ------------ | ------------------------------------- | ---------------------------------- |
-| Cyprus-1  | [0 0]      | N/A          | https://rpc.sandbox.quai.network:9200 | ws://rpc.sandbox.quai.network:8200 |
-| Cyprus-2  | [0 1]      | N/A          | https://rpc.sandbox.quai.network:9201 | ws://rpc.sandbox.quai.network:8201 |
-| Cyprus-3  | [0 2]      | N/A          | https://rpc.sandbox.quai.network:9202 | ws://rpc.sandbox.quai.network:8202 |
-| Paxos-1   | [1 0]      | N/A          | https://rpc.sandbox.quai.network:9220 | ws://rpc.sandbox.quai.network:8220 |
-| Paxos-2   | [1 1]      | N/A          | https://rpc.sandbox.quai.network:9221 | ws://rpc.sandbox.quai.network:8221 |
-| Paxos-3   | [1 2]      | N/A          | https://rpc.sandbox.quai.network:9222 | ws://rpc.sandbox.quai.network:8222 |
-| Hydra-1   | [2 0]      | N/A          | https://rpc.sandbox.quai.network:9240 | ws://rpc.sandbox.quai.network:8240 |
-| Hydra-2   | [2 1]      | N/A          | https://rpc.sandbox.quai.network:9241 | ws://rpc.sandbox.quai.network:8241 |
-| Hydra-3   | [2 2]      | N/A          | https://rpc.sandbox.quai.network:9242 | ws://rpc.sandbox.quai.network:8242 |
+<Info>
+	The public devnet RPC does not currently support `https` interactions. Please use `http` based URLs until `https` has been enabled.
+</Info>
+
+| Zone Name | Zone Index | Explorer URL | RPC Endpoint (http)                  | RPC Endpoint (Websocket)           |
+| --------- | ---------- | ------------ | ------------------------------------ | ---------------------------------- |
+| Cyprus-1  | [0 0]      | N/A          | http://rpc.sandbox.quai.network:9200 | ws://rpc.sandbox.quai.network:8200 |
+| Cyprus-2  | [0 1]      | N/A          | http://rpc.sandbox.quai.network:9201 | ws://rpc.sandbox.quai.network:8201 |
+| Cyprus-3  | [0 2]      | N/A          | http://rpc.sandbox.quai.network:9202 | ws://rpc.sandbox.quai.network:8202 |
+| Paxos-1   | [1 0]      | N/A          | http://rpc.sandbox.quai.network:9220 | ws://rpc.sandbox.quai.network:8220 |
+| Paxos-2   | [1 1]      | N/A          | http://rpc.sandbox.quai.network:9221 | ws://rpc.sandbox.quai.network:8221 |
+| Paxos-3   | [1 2]      | N/A          | http://rpc.sandbox.quai.network:9222 | ws://rpc.sandbox.quai.network:8222 |
+| Hydra-1   | [2 0]      | N/A          | http://rpc.sandbox.quai.network:9240 | ws://rpc.sandbox.quai.network:8240 |
+| Hydra-2   | [2 1]      | N/A          | http://rpc.sandbox.quai.network:9241 | ws://rpc.sandbox.quai.network:8241 |
+| Hydra-3   | [2 2]      | N/A          | http://rpc.sandbox.quai.network:9242 | ws://rpc.sandbox.quai.network:8242 |
 
 ## Colosseum Testnet
 
 <Warning>
-  The public testnet is currently running the stable **Iron Age Testnet** version of the Quai Protocol, compatible with [quais v1.1.17](https://www.npmjs.com/package/quais/v/0.1.17) only.
-
-If you are a developer starting to build an application, it is recommend that you build on the public devnet with the latest protocol and SDK versions in preparation for the **Golden Age Testnet**.
-
+	**The Colosseum testnet is not currently live.** If you are a developer starting to build an application, you should start building on the
+	[public devnet](#devnet) with the latest protocol and SDK versions in preparation for the **Golden Age Testnet**.
 </Warning>
 
-The Colosseum Testnet serves as a place to experiment with new features and ensure they are stable for Mainnet release. This network can be used by all to interact with the current stable version of the network. Colosseum is currently running the **Iron Age Testnet** version of the Quai Protocol, but will be upgraded to the Golden Age Testnet version when the Golden Age Testnet is publicly released in the near future.
+The Colosseum Testnet serves as a place to experiment with new features and ensure they are stable for Mainnet release. When live, this network can be used by all to interact with the current stable version of the network. Colosseum is not currently live, but will be released running the Golden Age Testnet version of go-quai when the Golden Age Testnet is publicly released in the near future.
 
 QUAI on the testnet has no real value and thus testing deployments, interactions, and smart contracts are virtually free. As testnet QUAI has no value, there are _no markets_ to purchase testnet tokens.
 
-Developers looking to test can easily mint testnet QUAI from the [testnet faucet](https://faucet.quai.network). Faucets generally are a simple web interfaces which you can input an address where you'd like tokens to be sent. Additionally, you can spin up a miner and mine blocks to acquire testnet QUAI tokens.
-
-The Quai Network testnet is named `colosseum` as it's where network upgrades go to "fight it out" prior to being pushed up to mainnet. To point your node and miner to testnet, you'll have to edit your `network.env` file to:
-
-```
-NETWORK=colosseum
-NONCE=5926993
-```
+The Quai Network testnet is named `colosseum` as it's where network upgrades go to "fight it out" prior to being pushed up to mainnet.
 
 ### Network Specifications
 
@@ -80,28 +82,11 @@ NONCE=5926993
 	>
 		5926993
 	</Card>
-	<Card
-		title='Faucet'
-		href='https://faucet.quai.network'
-		icon='faucet'
-	>
-		Colosseum Faucet
-	</Card>
 </CardGroup>
 
 #### Explorer URLs and RPC Endpoints
 
-| Zone Name | Zone Index | Explorer URL                           | RPC Endpoint                              |
-| --------- | ---------- | -------------------------------------- | ----------------------------------------- |
-| Cyprus-1  | [0 0]      | https://cyprus1.colosseum.quaiscan.io/ | https://rpc.cyprus1.colosseum.quaiscan.io |
-| Cyprus-2  | [0 1]      | https://cyprus2.colosseum.quaiscan.io/ | https://rpc.cyprus2.colosseum.quaiscan.io |
-| Cyprus-3  | [0 2]      | https://cyprus3.colosseum.quaiscan.io/ | https://rpc.cyprus3.colosseum.quaiscan.io |
-| Paxos-1   | [1 0]      | https://paxos1.colosseum.quaiscan.io/  | https://rpc.paxos1.colosseum.quaiscan.io  |
-| Paxos-2   | [1 1]      | https://paxos2.colosseum.quaiscan.io/  | https://rpc.paxos2.colosseum.quaiscan.io  |
-| Paxos-3   | [1 2]      | https://paxos3.colosseum.quaiscan.io/  | https://rpc.paxos3.colosseum.quaiscan.io  |
-| Hydra-1   | [2 0]      | https://hydra1.colosseum.quaiscan.io/  | https://rpc.hydra1.colosseum.quaiscan.io  |
-| Hydra-2   | [2 1]      | https://hydra2.colosseum.quaiscan.io/  | https://rpc.hydra2.colosseum.quaiscan.io  |
-| Hydra-3   | [2 2]      | https://hydra3.colosseum.quaiscan.io/  | https://rpc.hydra3.colosseum.quaiscan.io  |
+<Info>There are currently no live RPC endpoints or explorers for the Colosseum testnet.</Info>
 
 ## Local Network
 

--- a/guides/development/solidity.mdx
+++ b/guides/development/solidity.mdx
@@ -15,6 +15,7 @@ To deploy single chain smart contracts on Quai, we'll need a few tool-kits and d
 | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | [**NodeJS**](https://nodejs.org/en/download/)                                 | Javascript runtime environment. Use the LTS version.                         |
 | [**hardhat-example**](https://github.com/dominant-strategies/hardhat-example) | A Hardhat project with sample contracts and deploy scripts for Quai Network. |
+| [**Quais.js**](https://www.npmjs.com/package/quais)                           | A JavaScript library for interacting with Quai Network.                      |
 
 ## Environment Setup
 
@@ -30,18 +31,23 @@ npm install
 
 ### Smart Contracts
 
-The `Solidity` directory comes with 2 sample contracts: `ERC20.sol` and `ERC721.sol` inside of the `contracts/` directory. Both contracts are implementations derived from the [Open Zeppelin library](https://www.openzeppelin.com/contracts).
+The `Solidity/` directory comes with 2 sample contracts: `ERC20.sol` and `ERC721.sol` inside of the `contracts/` directory. Both contracts are implementations derived from the [Open Zeppelin library](https://www.openzeppelin.com/contracts).
 
 We'll be using the `ERC20.sol` sample contract for this tutorial, but you can also add your own contracts or use contracts from other libraries.
+
+<Warning>
+	The Quai Network EVM supports Solidity versions up to 0.8.20. Using a newer version of Solidity may result in errors when deploying smart
+	contracts.
+</Warning>
 
 ### Environment Variables
 
 We've included a sample environment file, `.env.dist`, file at the root of the `hardhat-example` repo to manage token details, private keys, and RPC URLs in a secure fashion.
 
 <Note>
-The `.env.dist` file is a template file and should not be used as is. You should copy the `.env.dist` file to a new `.env` file in the repository root using the following command:
+The `.env.dist` file is a template file and should not be used as is. You should copy the `.env.dist` file to a new `.env` file.
 
-This file lives at the root of the `hardhat-example` repository and serves as the config file for both the `Solidity` and `SolidityX` directories.
+This file lives at the root of the `hardhat-example` repository and serves as the config file for both the `Solidity/` and `SolidityX/` directories.
 
 </Note>
 
@@ -55,17 +61,16 @@ Open the `.env` file and add your private keys, RPC URLs, and token args for the
 
 ```bash .env
 # Unique Privkey for each deployment address
-CYPRUS1PK="0x3700000000000000000000000000000000000000000000000000000000000000" # For pubkey starting with 0x00 - 0x1D
-CYPRUS2PK="0x9400000000000000000000000000000000000000000000000000000000000000" # For pubkey starting with 0x1E - 0x3A
+CYPRUS1PK="0x3700000000000000000000000000000000000000000000000000000000000000" # pubkey starting with 0x00
+CYPRUS2PK="0x9400000000000000000000000000000000000000000000000000000000000000" # pubkey starting with 0x01
 ...more priv keys
 
-# Chain ID (local: 1337, testnet: 9000, devnet: 12000)
+# Chain ID (local: 1337, testnet and devnet: 9000)
 CHAINID="9000"
 
 # RPC endpoints
-CYPRUS1URL="https://rpc.cyprus1.colosseum.quaiscan.io"
-CYPRUS2URL="https://rpc.cyprus2.colosseum.quaiscan.io"
-CYPRUS3URL="https://rpc.cyprus3.colosseum.quaiscan.io"
+CYPRUS1URL="https://rpc.sandbox.quai.network:9200"
+CYPRUS2URL="https://rpc.sandbox.quai.network:9201"
 ...more rpc urls
 
 # Token Arguments
@@ -79,13 +84,13 @@ All of the `RPCURL` values have already been filled in for you, but you can chan
 
 </Note>
 
-Further information on RPC endpoints can be found in the [local network specifications](/build/networks#local-network) section for **local nodes** and the [testnet specifications](/build/networks#colosseum-testnet) section for **remote nodes**.
+Further information on RPC endpoints can be found in the [local network specifications](/build/networks#local-network) section for **local nodes** and the [devnet specifications](/build/networks#devnet) section for **remote nodes**.
 
 After filling in your private keys, RPC URLs, we're now ready to securely consume them inside of `hardhat.config.js`.
 
 ### Hardhat Configuration
 
-Hardhat uses `hardhat.config.js` to configure smart contract deployments. The config file allows you to define deployment networks, tasks, compilers, etc.
+Hardhat uses a `hardhat.config.js` file to configure smart contract deployments. The config file allows you to define deployment networks, tasks, compilers, etc.
 
 `hardhat-example` contains a prebuilt `hardhat.config.js` file with configurations for deploying and verifying smart contracts on any shard in the network.
 
@@ -126,38 +131,22 @@ Hardhat uses `hardhat.config.js` to configure smart contract deployments. The co
           },
         },
       },
-
-    etherscan: {
-        apiKey: {
-          cyprus1: "abc",
-          ...more api keys
-        },
-        customChains: [
-          {
-            network: "cyprus1",
-            chainId: Number(process.env.CHAINID),
-            urls: {
-              apiURL: "https://cyprus1.colosseum.quaiscan.io/api",
-              browserURL: "https://cyprus1.colosseum.quaiscan.io",
-            },
-          },
-          ...more verification configs
-        ],
-      },
     };
-  ```
+    ```
+    <Warning>
+      The Golden Age devnet currently supports Cyprus 1 and 2. All other shards are not running in the current network configuration.
+    </Warning>
+    Inside the config file you can find deployment and verification definitions for:
 
-  Inside the config file you can find deployment and verification definitions for:
-
-  - `cyprus1`
-  - `cyprus2`
-  - `cyprus3`
-  - `paxos1`
-  - `paxos2`
-  - `paxos3`
-  - `hydra1`
-  - `hydra2`
-  - `hydra3`
+    - `cyprus1`
+    - `cyprus2`
+    - `cyprus3`
+    - `paxos1`
+    - `paxos2`
+    - `paxos3`
+    - `hydra1`
+    - `hydra2`
+    - `hydra3`
 
 </Accordion>
 
@@ -182,62 +171,53 @@ When deploying or verifying a contract, `hardhat.config.js` will pull your priva
 
     Compiled 2 Solidity files successfully
     ```
+
   </Step>
   <Step title="Configure deployment scripts">
-    Inside the `scripts/` directory, you'll find a deploy script for both `ERC20.sol` and `ERC721.sol`: `deployERC20.js` and `deployERC721.js`. For this tutorial, we'll be using `deployERC20.js`.
+    Inside the `scripts/` directory, you'll find a deploy script for both the ERC20 and ERC721 contracts: `deployERC20.js` and `deployERC721.js`. For this tutorial, we'll be deploying an ERC20 contract.
 
-    The `deployERC20.js` script pulls your network configuration from `hardhat.config.js` and your token arguments from the `.env` file at the root of the repository and uses them to deploy your contract.
+      The `deployERC20.js` script pulls your network configuration from `hardhat.config.js` and your token arguments from the `.env` file at the root of the repository and uses them to deploy your contract.
 
-    Token arguments are consumed via the `tokenArgs` object:
+      Token arguments are consumed via the `tokenArgs` array:
 
-    ```js
-    tokenArgs = {
-      name: process.env.ERC20_NAME, // Name of token
-      symbol: process.env.ERC20_SYMBOL, // Symbol of token
-      initialSupply: process.env.ERC20_INITIALSUPPLY, // Initial supply of token, will be minted to deployer
-    }
-    ```
+      ```js
+      const tokenArgs = [process.env.ERC20_NAME, process.env.ERC20_SYMBOL, quais.parseUnits(process.env.ERC20_INITIALSUPPLY)]
+      ```
 
-    Your specified network configuration is consumed inside of the `provider` and `wallet` variables in tandem with the compiled contract ABI and bytecode to create a new contract instance:
+      Your specified network configuration and deployment account is consumed inside of the `provider` and `wallet` variables in tandem with the compiled contract ABI and bytecode to create a new contract instance:
 
-    ```js
-    const provider = new quais.providers.JsonRpcProvider(hre.network.config.url)
-    const wallet = new quais.Wallet(hre.network.config.accounts[0], provider)
-    const ERC20 = new quais.ContractFactory(ERC20Json.abi, ERC20Json.bytecode, wallet)
-    ```
+      ```js
+      const provider = new quais.JsonRpcProvider(hre.network.config.url)
+      const wallet = new quais.Wallet(hre.network.config.accounts[0], provider)
+      const ERC20 = new quais.ContractFactory(ERC20Json.abi, ERC20Json.bytecode, wallet)
+      ```
 
-    We'll use these ideas to properly modify the token args and network specification to deploy our contract in the next step.
+      We'll use these ideas to properly modify the token args and network specification to deploy our contract in the next step.
 
     <Tip>
       The `deployERC721.js` script functions in a similar manner, but with different contract arguments and a different contract ABI and
       bytecode. You can replicate this configuration for any contract you'd like to deploy.
     </Tip>
+
   </Step>
   <Step title="Deploy your contract">
     The deploy script takes in a `--network` flag to specify the network you'd like to deploy to (available options can be found [here](#hardhat-configuration)). For this tutorial, we'll be deploying to `cyprus1`.
-
     ```bash
     npx hardhat run scripts/deployERC20.js --network cyprus1
     ```
-
     Which should output:
-
     ```bash
-    1 -- Deploy transaction broadcasted: 0x235fdeb85db5b6cee8da9780e2246907e8342751849f5ce3514847a5dffd916f
-    2 -- Waiting for transaction to be mined.
-    3 -- Transaction mined. ERC20 deployed to: 0x13d8c5fc0AB5A87870353f3C0409c102f2a772A9
-      -- Gas used: 249168
+    Transaction broadcasted: 0x235fdeb85db5b6cee8da9780e2246907e8342751849f5ce3514847a5dffd916f
+    Contract deployed to:  0x00735E9B2c731Fd3eCC8129a3653ACb99dF969cC
     ```
-
     Congratulations, you've now deployed a ERC20 token to Quai Network!
-
     <Warning>
       The `ERC20.sol` and `ERC721.sol` sample contracts are basic implementations of each token for example purposes. It is highly recommended
       to modify these contracts to fit your specific use case before deploying them for any production use.
     </Warning>
   </Step>
   <Step title="Interact with the contract">
-    Hardhat console does not currently offer support for interaction with smart contracts on Quai Network. In order to interact with your smart contract, you'll need to utilize the the [client JSON RPC](/build/playground) or [quais.js](https://www.npmjs.com/package/quais) library. You can find quais examples in the [quais-by-example](https://github.com/dominant-strategies/quais-by-example) repository.
+    Hardhat console does not currently offer support for interaction with smart contracts on Quai Network. In order to interact with your smart contract, you'll need to utilize the the [client JSON RPC](/build/playground/overview) or [quais.js](https://www.npmjs.com/package/quais) library. You can find examples in the [hardhat-example](https://github.com/dominant-strategies/hardhat-example) repository.
   </Step>
 </Steps>
 

--- a/guides/development/solidityX.mdx
+++ b/guides/development/solidityX.mdx
@@ -11,18 +11,20 @@ We'll be using the basic implementation of a [QRC721 token](https://github.com/d
 
 ## Prerequisites
 
-To deploy single chain smart contracts on Quai, we'll need a few tool-kits and dependencies. Here's an overview of all of the dependencies we'll be using:
+To deploy multi chain smart contracts on Quai, we'll need a few tool-kits and dependencies. Here's an overview of all of the dependencies we'll be using:
 
 |                                                                               |                                                                              |
 | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | [**NodeJS**](https://nodejs.org/en/download/)                                 | Javascript runtime environment. Use the LTS version.                         |
 | [**hardhat-example**](https://github.com/dominant-strategies/hardhat-example) | A Hardhat project with sample contracts and deploy scripts for Quai Network. |
+| [**Quais.js**](https://www.npmjs.com/package/quais)                           | A JavaScript library for interacting with Quai Network.                      |
+| [**quai-hardhat-plugin**](https://www.npmjs.com/package/quai-hardhat-plugin)  | A plugin built for Hardhat that provides support for the SolidityX compiler. |
 
 ## Environment Setup
 
 ### Dependencies
 
-Start by cloning the `hardhat-example` repository, navigating to the `SolidityX` directory we'll be using for this tutorial, and installing the dependencies via `npm`.
+Start by cloning the `hardhat-example` repository, navigating to the `SolidityX/` directory we'll be using for this tutorial, and installing the dependencies via `npm`.
 
 ```bash
 git clone https://github.com/dominant-strategies/hardhat-example.git
@@ -32,7 +34,7 @@ npm install
 
 <Tip>
 	If you've already cloned the `hardhat-example` repository for the [Single-Chain Deployment Tutorial](/guides/development/solidity), you
-	can skip the cloning step. Just navigate to the `SolidityX` directory and run `npm install`.
+	can skip the cloning step. Just navigate to the `SolidityX/` directory and run `npm install`.
 </Tip>
 
 ### Smart Contracts
@@ -43,7 +45,7 @@ As mentioned above, we'll be deploying the [QRC721 smart contract](https://githu
 
 ### Environment Variables
 
-We've included a sample environment file, [`.env.dist`](https://github.com/dominant-strategies/hardhat-example/blob/main/.env.dist), file at the root of the `hardhat-example` repo to hold token details, private keys, and RPC URLs in a secure fashion.
+We've included a sample [.env.dist](https://github.com/dominant-strategies/hardhat-example/blob/main/.env.dist) environment file at the root of the `hardhat-example` repo to hold token details, private keys, and RPC URLs in a secure fashion.
 
 <Note>
 The `.env.dist` file is a template file and should not be used as is. You should copy the `.env.dist` file to a new `.env` file in the repository root using the following command:
@@ -62,17 +64,16 @@ Open the `.env` file and add your private keys, RPC URLs, and token args for the
 
 ```bash .env
 # Unique Privkey for each deployment address
-CYPRUS1PK="0x3700000000000000000000000000000000000000000000000000000000000000" # For pubkey starting with 0x00 - 0x1D
-CYPRUS2PK="0x9400000000000000000000000000000000000000000000000000000000000000" # For pubkey starting with 0x1E - 0x3A
+CYPRUS1PK="0x3700000000000000000000000000000000000000000000000000000000000000" # pubkey starting with 0x00
+CYPRUS2PK="0x9400000000000000000000000000000000000000000000000000000000000000" # pubkey starting with 0x01
 ...more priv keys
 
-# Chain ID (local: 1337, testnet: 9000, devnet: 12000)
+# Chain ID (local: 1337, testnet and devnet: 9000)
 CHAINID="9000"
 
 # RPC endpoints
-CYPRUS1URL="https://rpc.cyprus1.colosseum.quaiscan.io"
-CYPRUS2URL="https://rpc.cyprus2.colosseum.quaiscan.io"
-CYPRUS3URL="https://rpc.cyprus3.colosseum.quaiscan.io"
+CYPRUS1URL="https://rpc.sandbox.quai.network:9200"
+CYPRUS2URL="https://rpc.sandbox.quai.network:9201"
 ...more rpc urls
 
 # Token Arguments
@@ -101,7 +102,6 @@ The below configuration file has **two main differences** from the `hardhat.conf
 
 <Accordion title="Sample hardhat configuration file" icon="file" iconType="solid">
   This sample configuration file is provided as part of the `hardhat-example` repository.
-
   ```javascript hardhat.config.js
   /**
    * @type import('hardhat/config').HardhatUserConfig
@@ -145,27 +145,11 @@ The below configuration file has **two main differences** from the `hardhat.conf
         },
       },
     },
-
-  etherscan: {
-      apiKey: {
-        cyprus1: "abc",
-        ...more api keys
-      },
-      customChains: [
-        {
-          network: "cyprus1",
-          chainId: Number(process.env.CHAINID),
-          urls: {
-            apiURL: "https://cyprus1.colosseum.quaiscan.io/api",
-            browserURL: "https://cyprus1.colosseum.quaiscan.io",
-          },
-        },
-        ...more verification configs
-      ],
-    },
   };
   ```
-
+  <Warning>
+    The Golden Age devnet currently supports Cyprus 1 and 2. All other shards are not running in the current network configuration.
+  </Warning>
   Inside the config file you can find deployment and verification definitions for:
 
   - `cyprus1`
@@ -177,7 +161,6 @@ The below configuration file has **two main differences** from the `hardhat.conf
   - `hydra1`
   - `hydra2`
   - `hydra3`
-
 </Accordion>
 
 When deploying or verifying a contract, `hardhat.config.js` will pull your private keys and RPC URLs from the `.env` file and use them to deploy and verify your contracts.
@@ -186,7 +169,7 @@ When deploying or verifying a contract, `hardhat.config.js` will pull your priva
 
 To be able to properly compile and deploy SolidityX contracts, we'll need the [SolidityX](https://github.com/dominant-strategies/SolidityX). There are two methods of installing the SolidityX compiler for use with Hardhat:
 
-- Install the SolidityX compiler via [`quai-hardhat-plugin`](https://www.npmjs.com/package/quai-hardhat-plugin) (**Recommended**)
+- Install the SolidityX compiler via [quai-hardhat-plugin](https://www.npmjs.com/package/quai-hardhat-plugin) (**Recommended**)
 - Install and build the SolidityX compiler from source
 
 <Tabs>
@@ -202,6 +185,7 @@ To be able to properly compile and deploy SolidityX contracts, we'll need the [S
     Visit the [SolidityX Repository](https://github.com/dominant-strategies/SolidityX) for instructions on how to clone and build the SolidityX compiler for your specific operating system.
 
     Once you've built the SolidityX compiler, you'll need to add path to your `solc` binary into the `compilerPath` variable in the `solidityX` object in your `hardhat.config.js`. The file already includes common paths for MacOS and Linux as comments.
+
   </Tab>
 </Tabs>
 
@@ -225,31 +209,29 @@ To be able to properly compile and deploy SolidityX contracts, we'll need the [S
 
     Compiled 2 Solidity files successfully (evm target: istanbul).
     ```
+
   </Step>
   <Step title="Configure deployment scripts">
-    Inside the `scripts/` directory, you'll find a deploy script for both `QRC20.sol` and `QRC721.sol`: `deployQRC20.js` and `deployQRC721.js`. For this tutorial, we'll be using `deployQRC721.js`.
+    Inside the `scripts/` directory, you'll find a deploy script for both QRC20 and QRC721 contracts: `deployQRC20.js` and `deployQRC721.js`. For this tutorial, we'll be using the QRC721 contract.
 
     The `deployQRC721.js` script works by pulling your specified network/accounts config from `hardhat.config.js` and the QRC721 arguments specified in the `.env` file at the root of the repository and uses them to deploy your contract.
 
-    Token arguments are consumed via the `tokenArgs` object:
+    Token arguments are consumed via the `tokenArgs` array:
 
     ```javascript
-    const tokenArgs = {
-      name: process.env.QRC721NAME,
-      symbol: process.env.QRC721SYMBOL,
-      baseURI: process.env.QRC721BASEURI,
-    }
+    const tokenArgs = [process.env.QRC721_NAME, process.env.QRC721_SYMBOL, process.env.QRC721_BASE_URI]
     ```
 
     Your specified network configuration is consumed inside of the `provider` and `wallet` variables in tandem with the compiled contract ABI and bytecode to create a new contract instance:
 
     ```javascript
-    const provider = new quais.providers.JsonRpcProvider(hre.network.config.url)
+    const provider = new quais.JsonRpcProvider(hre.network.config.url)
     const wallet = new quais.Wallet(hre.network.config.accounts[0], provider)
-    const contract = new quais.ContractFactory(QRC721.abi, QRC721.bytecode, wallet)
+    const QRC721 = new quais.ContractFactory(QRC721Json.abi, QRC721Json.bytecode, wallet)
     ```
 
     We'll use these ideas to properly modify the token args and network specification to deploy our contracts in the next step.
+
   </Step>
   <Step title="Deploy contracts">
     For this tutorial, we'll be deploying **two instances** of our QRC721 contract on two different chains. You can extend the methodology used here to deploy and link contracts to any combination of shards within Quai Network.
@@ -263,10 +245,8 @@ To be able to properly compile and deploy SolidityX contracts, we'll need the [S
     Running this should output:
 
     ```bash
-    1 -- Deploy transaction broadcasted: 0xb3c0a0d0f3bc47f4bcd5df67666d76246636741afb6134c2ba4145c51ed030d3
-    2 -- Waiting for transaction to be mined.
-    3 -- Transaction mined. QRC721 deployed to: 0x1A3fA2C0B9c490a07a421d2b169E034C1bFcA601
-      -- Gas used: 293212
+    Transaction broadcasted: 0x018100ff42c92c99ddfe8f577ce63743769ae2daf46ad2032eec3bc3f803961d
+    Contract deployed to: 0x00735E9B2c731Fd3eCC8129a3653ACb99dF969cC
     ```
 
     Now, we can deploy an identical QRC721 contract to another shard within Quai, like Cyprus-2. Like before, you'll pass `cyprus2` as the network flag in the deployment command.
@@ -283,15 +263,14 @@ To be able to properly compile and deploy SolidityX contracts, we'll need the [S
     Which again should output something like this:
 
     ```bash
-    1 -- Deploy transaction broadcasted: 0xf6802822b4f1994d0be4ae03e2b1302ed42f3b95bf0c4607f3fae671f9719333
-    2 -- Waiting for transaction to be mined.
-    3 -- Transaction mined. QRC721 deployed to: 0x2F4C5243BEd5dC46787378894eDF662Db9FE4685
-      -- Gas used: 293543
+    Transaction broadcasted: 0x01b40095e3d8e9d498a1ee8eb0500b832a3c98abf9b787fcc63a91c37585fbe7
+    Contract deployed to: 0x0172F38EC31f58B1419E2CcE2B05B095625218ea
     ```
 
     We've now deployed our test QRC721 contract to both the Cyprus-1 and Cyprus-2 chains!
 
     <Note>Make sure to save these two contract addresses, we'll need them in the next section.</Note>
+
   </Step>
 </Steps>
 
@@ -329,11 +308,10 @@ Then, paste the following code into `addApprovedAddresses.js`:
 
 ```javascript addApprovedAddresses.js
 const quais = require('quais')
-const { pollFor } = require('quais-polling')
 const QRC721 = require('../artifacts/contracts/QRC721.sol/QRC721.json')
 
 async function AddApprovedQRC721Addresses() {
-	const provider = new quais.providers.JsonRpcProvider(hre.network.config.url)
+	const provider = new quais.JsonRpcProvider(hre.network.config.url)
 	const privateKey = hre.network.config.accounts[0]
 	const wallet = new quais.Wallet(privateKey, provider)
 	const contractAddress = 'contract address you want to change the address array for' // contract address to add approved addresses to
@@ -343,8 +321,7 @@ async function AddApprovedQRC721Addresses() {
 			[0, 1], // chain indexes (cyprus1 is 0, cyprus2 is 1, etc.)
 			['0x1...', '0x2....'] // contract addresses (must be in same order as chain indexes)
 		)
-		console.log('Transaction sent:', tx.hash)
-		const txReceipt = await pollFor(provider, 'getTransactionReceipt', [tx.hash], 1.5, 1)
+		const txRecipt = await tx.wait()
 		console.log('Transaction mined with hash', txReceipt.hash)
 	} catch (error) {
 		console.error('Error sending transaction:', error)
@@ -352,18 +329,26 @@ async function AddApprovedQRC721Addresses() {
 }
 
 AddApprovedQRC721Addresses()
+  .then(() => process.exit(0))
+    .catch((error) => {
+      console.error(error)
+      process.exit(1)
+    })
 ```
 
 The `addApprovedAddresses.js` script uses the `QRC721.sol` ABI to compose and send a transaction that inserts new addresses to the `approvedAddresses` array in any deployed QRC721 contract.
 
-<Accordion title="How the linking script works">
-    1. First, creating a quais `provider` with our specified network configuration from Hardhat
-    2. Creating a quais `wallet` with our `provider` and key config from Hardhat
-    3. Defining the contract we'd like to add an approved address to with the imported `QRC721.sol` ABI, contract address, and `wallet`
-    4. Composing the `addApprovedAddresses` transaction with the inputs
-      1. `chainIndex` array: integer chain indices corresponding to the addresses we'd like to add to `approvedAddresses`
-      2. `address` array: the contract addresses that we'd like to add to `approvedAddresses`
-    5. Sending the transaction and waiting for inclusion in a block.
+<Accordion title='How the linking script works'>
+	1. First, creating a quais `provider` with our specified network configuration from Hardhat 
+  2. Creating a quais `wallet` with our
+	`provider` and key config from Hardhat 
+  3. Defining the contract we'd like to add an approved address to with the imported `QRC721.sol`
+	ABI, contract address, and `wallet` 
+  4. Composing the `addApprovedAddresses` transaction with the inputs 
+     - `chainIndex` array: integer chain indices corresponding to the addresses we'd like to add to `approvedAddresses` 
+     - `address` array: the contract addresses that we'd
+	like to add to `approvedAddresses` 
+  5. Sending the transaction and waiting for inclusion in a block.
 </Accordion>
 
 After you've pasted the code for the linking script into the `addApprovedAddresses.js` file, we're ready to start linking our sister contracts.
@@ -375,8 +360,8 @@ After you've pasted the code for the linking script into the `addApprovedAddress
     Start by grabbing the addresses of the two contracts we deployed in the [deploy section](#deploy-your-contracts).
 
     ```bash
-    Cyprus 1 contract address: 0x1A3fA2C0B9c490a07a421d2b169E034C1bFcA601
-    Cyprus 2 contract address: 0x2F4C5243BEd5dC46787378894eDF662Db9FE4685
+    Cyprus 1 contract address: 0x00735E9B2c731Fd3eCC8129a3653ACb99dF969cC
+    Cyprus 2 contract address: 0x0172F38EC31f58B1419E2CcE2B05B095625218ea
     ```
 
     We'll take these contract addresses and use them to build the transaction data passed to the `addApprovedAddresses` method.
@@ -389,14 +374,14 @@ After you've pasted the code for the linking script into the `addApprovedAddress
     The transaction data we'll need to pass to the `addApprovedAddresses` method is **(notice the order of the arrays)**:
 
     - `chainIndex` array: `[0, 1]`
-    - `address` array: `['0x1A3fA2C0B9c490a07a421d2b169E034C1bFcA601', '0x2F4C5243BEd5dC46787378894eDF662Db9FE4685']
+    - `address` array: `['0x00735E9B2c731Fd3eCC8129a3653ACb99dF969cC', '0x0172F38EC31f58B1419E2CcE2B05B095625218ea']`
 
     The built transaction should look similar to this:
 
     ```javascript
     const transactionData = await contract.populateTransaction.AddApprovedAddress(
       [0, 1], // chain indexes [cyprus1, cyprus2]
-      ['0x1A3fA2C0B9c490a07a421d2b169E034C1bFcA601', '0x2F4C5243BEd5dC46787378894eDF662Db9FE4685'] // contract addresses [cyprus1, cyprus2]
+      ['0x00735E9B2c731Fd3eCC8129a3653ACb99dF969cC', '0x0172F38EC31f58B1419E2CcE2B05B095625218ea'] // contract addresses [cyprus1, cyprus2]
     )
     ```
 
@@ -405,12 +390,13 @@ After you've pasted the code for the linking script into the `addApprovedAddress
       addresses to the arrays. **Always make sure to add the same number of chain indexes and contract addresses to the arrays in matching
       order**.
     </Note>
+
   </Step>
   <Step title="Send linking transactions">
     First, we're going to send the linking transaction to our Cyprus 1 contract. To do this, start by changing the `contractAddress` variable to our **Cyprus 1 contract address** in the `addApprovedAddresses.js` script:
 
     ```javascript
-    const contractAddress = '0x1A3fA2C0B9c490a07a421d2b169E034C1bFcA601'
+    const contractAddress = '0x00735E9B2c731Fd3eCC8129a3653ACb99dF969cC'
     ```
 
     Now, we're ready to run the script and complete the Cyprus 1 contract linkage. Make sure to pass the `--network cyprus1` flag **when sending transactions to the Cyprus 1 contract**.
@@ -422,8 +408,8 @@ After you've pasted the code for the linking script into the `addApprovedAddress
     The script should output something like this:
 
     ```bash
-    Transaction sent: 0x2a499178c3f0046b4d44a57a966f9e224759c1b3158af984fcb5a1432b16ee8e
-    Transaction mined with hash: 0x2a499178c3f0046b4d44a57a966f9e224759c1b3158af984fcb5a1432b16ee8e
+    Transaction sent: 0x00499178c3f0046b4d44a57a966f9e224759c1b3158af984fcb5a1432b16ee8e
+    Transaction mined with hash: 0x00499178c3f0046b4d44a57a966f9e224759c1b3158af984fcb5a1432b16ee8e
     ```
 
     We've now linked our Cyprus 1 contract to our Cyprus 2 contract, but we're not done yet.
@@ -431,15 +417,16 @@ After you've pasted the code for the linking script into the `addApprovedAddress
     To finish linking these two sister contracts, we'll need to send the exact same transaction data to the Cyprus 2 contract. In the `addApprovedAddresses.js` script, change the `contractAddress` variable to **our Cyprus 2 contract address**:
 
     ```javascript
-    const contractAddress = '0x2F4C5243BEd5dC46787378894eDF662Db9FE4685'
+    const contractAddress = '0x0172F38EC31f58B1419E2CcE2B05B095625218ea'
     ```
 
     Lastly, send the linkage transaction to our Cyprus 2 token by running the script with the `--network cyprus2` flag:
 
     ```bash
-    Transaction sent: 0x348e8dea20b73089b51e6b3d2b3abd8a9e8ca63e06be20375cf721e13aabd590
-    Transaction mined with hash: 0x348e8dea20b73089b51e6b3d2b3abd8a9e8ca63e06be20375cf721e13aabd590
+    Transaction sent: 0x018e8dea20b73089b51e6b3d2b3abd8a9e8ca63e06be20375cf721e13aabd590
+    Transaction mined with hash: 0x018e8dea20b73089b51e6b3d2b3abd8a9e8ca63e06be20375cf721e13aabd590
     ```
+
   </Step>
 </Steps>
 
@@ -450,5 +437,6 @@ This deployment and linking process can be repeated for any number of chains wit
 For a more detailed example on how to deploy and link contracts across all shards within Quai Network, check out the [quais-by-example repo](https://github.com/dominant-strategies/quais-by-example/tree/main/contract-qrc721).
 
 <Note>
-	The same deploy and link method can be used for any other SolidityX based contract with cross-chain logic, including the [QRC-20 Token](https://github.com/dominant-strategies/SolidityX-Contracts/blob/main/QRC20X.sol).
+	The same deploy and link method can be used for any other SolidityX based contract with cross-chain logic, including the [QRC-20
+	Token](https://github.com/dominant-strategies/SolidityX-Contracts/blob/main/QRC20X.sol).
 </Note>

--- a/guides/miner/hiveos-manual.mdx
+++ b/guides/miner/hiveos-manual.mdx
@@ -137,28 +137,19 @@ sudo apt update && sudo apt upgrade -y
     Install CUDA with the following commands:
 
     ```bash
+    # Download CUDA Toolkit
     wget https://developer.download.nvidia.com/compute/cuda/12.1.0/local_installers/cuda_12.1.0_530.30.02_linux.run
+
+    # Run CUDA Installation Script
+    sudo sh cuda_12.1.0_530.30.02_linux.run --silent --toolkit
     ```
-
-    ```bash
-    sudo sh cuda_12.1.0_530.30.02_linux.run
-    ```
-
-    <Warning>
-      The above command will open a flow where you are able to select which components of the CUDA Toolkit you'd like to install. Ensure your
-      selections are **the same as the image below**.
-    </Warning>
-
-    <Frame>
-      <img src='/images/CUDAINSTALLEROPTIONS.jpeg' />
-    </Frame>
-
-    Unselect "Driver", and only select "CUDA Toolkit 12.1".
 
     <Info>
       After completing this step, you may see a warning saying that the CUDA compatible drivers were not installed -- as long as you previously
       ran `nvidia-driver-update`, you can safely ignore this warning.
     </Info>
+
+    After installing CUDA, reboot your machine to ensure all updates are applied correctly using:
 
     ```bash
     sreboot


### PR DESCRIPTION
- Update Hardhat Tutorials to use new address format and new Quais version
- Update Network specifications for Golden Age devnet release (chainIDs and RPC URLs)
  - Identify that IronAge testnet is no longer running for development
- Update CUDA toolkit install for HiveOS Manual installation as per requested by @Djadih  