### PR TITLE
Update rpc endpoints

### DIFF
--- a/build/apis/javascript-libraries.mdx
+++ b/build/apis/javascript-libraries.mdx
@@ -27,7 +27,7 @@ A complete Quai Network interaction library for JavaScript and TypeScript.
 	<Card
 		title='Examples'
 		icon='code'
-		href='https://github.com/dominant-strategies/quais-by-example'
+		href='https://github.com/dominant-strategies/quais.js/tree/master/examples'
 	/>
 </CardGroup>
 
@@ -47,7 +47,7 @@ Providers can query **any zone chain** in the network for:
 
 ```javascript
 // Connect to a remote node
-const provider = new quais.JsonRpcProvider('https://rpc.sandbox.quai.network')
+const provider = new quais.JsonRpcProvider('https://rpc.dev.quai.network', null, { usePathing: true })
 
 // Connect to an injected provider (e.g. Pelagus)
 const provider = new quais.BrowserProvider(window.pelagus)

--- a/build/networks.mdx
+++ b/build/networks.mdx
@@ -6,7 +6,7 @@ description: Specifications for Quai development and testing environments.
 ## Devnet
 
 <Tip>
-  The public developer network is currently running the **Golden Age Testnet** version of the Quai Protocol, compatible with [quais v1.0.0-alpha.8](https://www.npmjs.com/package/quais/v/1.0.0-alpha.8) and later.
+  The public developer network is currently running the **Golden Age Testnet** version of the Quai Protocol, compatible with [quais v1.0.0-alpha.8](https://www.npmjs.com/package/quais) and later.
 
 This network is designed for developers to test features prior to the official release of the Golden Age Testnet and **has no incentives**.
 
@@ -39,20 +39,21 @@ QUAI on the devnet has no real value and thus testing deployments, interactions,
 #### Explorer URLs and RPC Endpoints
 
 <Info>
-	The public devnet RPC does not currently support `https` interactions. Please use `http` based URLs until `https` has been enabled.
+	More detailed specifications for **port to shard** and **URL path to shard** mappings can be found in the [quai-nginx
+	repository](https://github.com/dominant-strategies/quai-nginx).
 </Info>
 
-| Zone Name | Zone Index | Explorer URL | RPC Endpoint (http)                  | RPC Endpoint (Websocket)           |
-| --------- | ---------- | ------------ | ------------------------------------ | ---------------------------------- |
-| Cyprus-1  | [0 0]      | N/A          | http://rpc.sandbox.quai.network:9200 | ws://rpc.sandbox.quai.network:8200 |
-| Cyprus-2  | [0 1]      | N/A          | http://rpc.sandbox.quai.network:9201 | ws://rpc.sandbox.quai.network:8201 |
-| Cyprus-3  | [0 2]      | N/A          | http://rpc.sandbox.quai.network:9202 | ws://rpc.sandbox.quai.network:8202 |
-| Paxos-1   | [1 0]      | N/A          | http://rpc.sandbox.quai.network:9220 | ws://rpc.sandbox.quai.network:8220 |
-| Paxos-2   | [1 1]      | N/A          | http://rpc.sandbox.quai.network:9221 | ws://rpc.sandbox.quai.network:8221 |
-| Paxos-3   | [1 2]      | N/A          | http://rpc.sandbox.quai.network:9222 | ws://rpc.sandbox.quai.network:8222 |
-| Hydra-1   | [2 0]      | N/A          | http://rpc.sandbox.quai.network:9240 | ws://rpc.sandbox.quai.network:8240 |
-| Hydra-2   | [2 1]      | N/A          | http://rpc.sandbox.quai.network:9241 | ws://rpc.sandbox.quai.network:8241 |
-| Hydra-3   | [2 2]      | N/A          | http://rpc.sandbox.quai.network:9242 | ws://rpc.sandbox.quai.network:8242 |
+| Zone Name | Zone Index | Explorer URL        | RPC Endpoint (https)                 | RPC Endpoint (wss)                 |
+| --------- | ---------- | ------------------- | ------------------------------------ | ---------------------------------- |
+| Cyprus-1  | [0 0]      | https://quaiscan.io | https://rpc.dev.quai.network/cyprus1 | wss://rpc.dev.quai.network/cyprus1 |
+| Cyprus-2  | [0 1]      | https://quaiscan.io | https://rpc.dev.quai.network/cyprus2 | wss://rpc.dev.quai.network/cyprus2 |
+| Cyprus-3  | [0 2]      | https://quaiscan.io | https://rpc.dev.quai.network/cyprus3 | wss://rpc.dev.quai.network/cyprus3 |
+| Paxos-1   | [1 0]      | N/A                 | https://rpc.dev.quai.network/paxos1  | wss://rpc.dev.quai.network/paxos1  |
+| Paxos-2   | [1 1]      | N/A                 | https://rpc.dev.quai.network/paxos2  | wss://rpc.dev.quai.network/paxos2  |
+| Paxos-3   | [1 2]      | N/A                 | https://rpc.dev.quai.network/paxos3  | wss://rpc.dev.quai.network/paxos3  |
+| Hydra-1   | [2 0]      | N/A                 | https://rpc.dev.quai.network/hydra1  | wss://rpc.dev.quai.network/hydra1  |
+| Hydra-2   | [2 1]      | N/A                 | https://rpc.dev.quai.network/hydra2  | wss://rpc.dev.quai.network/hydra2  |
+| Hydra-3   | [2 2]      | N/A                 | https://rpc.dev.quai.network/hydra3  | wss://rpc.dev.quai.network/hydra3  |
 
 ## Colosseum Testnet
 
@@ -115,20 +116,20 @@ You can easily spin up a pre-configured development environment using the [Local
 
 ### Networking Information
 
-| Chain Name | Chain Index | HTTP Port |
-| ---------- | ----------- | --------- |
-| Prime      |             | 9000      |
-| Cyprus     |             | 9001      |
-| Paxos      |             | 9002      |
-| Hydra      |             | 9003      |
-| Cyprus1    | [0 0]       | 9200      |
-| Cyprus2    | [0 1]       | 9201      |
-| Cyprus3    | [0 2]       | 9202      |
-| Paxos1     | [1 0]       | 9220      |
-| Paxos2     | [1 1]       | 9221      |
-| Paxos3     | [1 2]       | 9222      |
-| Hydra1     | [2 0]       | 9240      |
-| Hydra2     | [2 1]       | 9241      |
-| Hydra3     | [2 2]       | 9242      |
+| Chain Name | Chain Index | HTTP Port | WS Port |
+| ---------- | ----------- | --------- | ------- |
+| Prime      |             | 9000      | 8000    |
+| Cyprus     |             | 9001      | 8001    |
+| Paxos      |             | 9002      | 8002    |
+| Hydra      |             | 9003      | 8003    |
+| Cyprus1    | [0 0]       | 9200      | 8200    |
+| Cyprus2    | [0 1]       | 9201      | 8201    |
+| Cyprus3    | [0 2]       | 9202      | 8202    |
+| Paxos1     | [1 0]       | 9220      | 8220    |
+| Paxos2     | [1 1]       | 9221      | 8221    |
+| Paxos3     | [1 2]       | 9222      | 8222    |
+| Hydra1     | [2 0]       | 9240      | 8240    |
+| Hydra2     | [2 1]       | 9241      | 8241    |
+| Hydra3     | [2 2]       | 9242      | 8242    |
 
 <Warning>Do not open the above HTTP ports for any reason. You will be putting your local network security at risk.</Warning>

--- a/build/playground/overview.mdx
+++ b/build/playground/overview.mdx
@@ -63,7 +63,7 @@ While some developers may opt to interact directly with the JSON-RPC API directl
 
 Each zone chain within Quai Network maintains a unique, local set of data. Each address, contract, and transaction made on the network "lives" in a specific zone chain, or a [sharded state](/learn/advanced-introduction/hierarchical-structure/sharding). A general understanding of this concept is required to effectively use the JSON RPC API to query data and interact with the network.
 
-To query data for a specific address, contract, or transaction, you must send your JSON RPC request to the corresponding zone chain. Each zone chain has a unique RPC endpoint URL or port number to communicate with. For example, the RPC endpoint URL for the Cyprus 1 zone chain is `https://rpc.cyprus1.colosseum.quaiscan.io`, to which you can query data for all Cyprus 1 addresses, contracts, and more. If you attempt to query a node for data that does not exist on the chain you are requesting to (_i.e. requesting a Paxos 1 node for Cyprus 1 address data_), the request will return an error.
+To query data for a specific address, contract, or transaction, you must send your JSON RPC request to the corresponding zone chain. Each zone chain has a unique RPC endpoint URL or port number to communicate with. For example, the RPC endpoint URL for the Cyprus 1 zone chain is `https://rpc.dev.quai.network/cyprus1`, to which you can query data for all Cyprus 1 addresses, contracts, and more. If you attempt to query a node for data that does not exist on the chain you are requesting to (_i.e. requesting a Paxos 1 node for Cyprus 1 address data_), the request will return an error.
 
 ### Protobuf Encoding
 

--- a/guides/development/solidity.mdx
+++ b/guides/development/solidity.mdx
@@ -42,7 +42,7 @@ We'll be using the `ERC20.sol` sample contract for this tutorial, but you can al
 
 ### Environment Variables
 
-We've included a sample environment file, `.env.dist`, file at the root of the `hardhat-example` repo to manage token details, private keys, and RPC URLs in a secure fashion.
+We've included a sample environment file, `.env.dist`, file at the root of the `hardhat-example` repo to manage token details, private keys, and your RPC URL in a secure fashion.
 
 <Note>
 The `.env.dist` file is a template file and should not be used as is. You should copy the `.env.dist` file to a new `.env` file.
@@ -61,32 +61,29 @@ Open the `.env` file and add your private keys, RPC URLs, and token args for the
 
 ```bash .env
 # Unique Privkey for each deployment address
-CYPRUS1PK="0x3700000000000000000000000000000000000000000000000000000000000000" # pubkey starting with 0x00
-CYPRUS2PK="0x9400000000000000000000000000000000000000000000000000000000000000" # pubkey starting with 0x01
+CYPRUS1_PK="0x3700000000000000000000000000000000000000000000000000000000000000" # pubkey starting with 0x00
+CYPRUS2_PK="0x9400000000000000000000000000000000000000000000000000000000000000" # pubkey starting with 0x01
 ...more priv keys
 
 # Chain ID (local: 1337, testnet and devnet: 9000)
-CHAINID="9000"
+CHAIN_ID="9000"
 
-# RPC endpoints
-CYPRUS1URL="https://rpc.sandbox.quai.network:9200"
-CYPRUS2URL="https://rpc.sandbox.quai.network:9201"
-...more rpc urls
+# RPC endpoint
+RPC_URL="https://rpc.dev.quai.network"
 
 # Token Arguments
 ...more token args
 ```
 
 <Note>
-The `PRIVKEY` values must all be for unique addresses and correspond to the chain name, i.e. your `CYPRUS1PK` should be the private key of your Cyprus-1 address.
-
-All of the `RPCURL` values have already been filled in for you, but you can change them to your own RPC URLs if you're running your own nodes.
-
+	The `PK` values must all be for unique addresses and correspond to the zone name, i.e. your `CYPRUS1_PK` should be the private key of your Cyprus1 address.
 </Note>
 
 Further information on RPC endpoints can be found in the [local network specifications](/build/networks#local-network) section for **local nodes** and the [devnet specifications](/build/networks#devnet) section for **remote nodes**.
 
-After filling in your private keys, RPC URLs, we're now ready to securely consume them inside of `hardhat.config.js`.
+The `hardhat-example` repository uses the [Quais SDK](/sdk/introduction) to configure network connections using only a single RPC URL. To learn more about how the SDK configures network providers, visit the [SDK provider examples](/sdk/static/provider) section.
+
+After filling in your private keys, RPC URL, we're now ready to securely consume them inside of `hardhat.config.js`.
 
 ### Hardhat Configuration
 
@@ -106,18 +103,21 @@ Hardhat uses a `hardhat.config.js` file to configure smart contract deployments.
     const dotenv = require("dotenv");
     dotenv.config({ path: "../.env" });
 
+    const rpcUrl = process.env.RPC_URL;
+    const chainId = Number(process.env.CHAIN_ID);
+
     module.exports = {
       defaultNetwork: "cyprus1",
       networks: {
         cyprus1: {
-          url: `${process.env.CYPRUS1URL}`,
-          accounts: [process.env.CYPRUS1PK],
-          chainId: Number(process.env.CHAINID),
+          url: rpcUrl,
+          accounts: [process.env.CYPRUS1_PK],
+          chainId: chainId,
         },
         cyprus2: {
-          url: `${process.env.CYPRUS2URL}`,
-          accounts: [process.env.CYPRUS2PK],
-          chainId: Number(process.env.CHAINID),
+          url: rpcUrl,
+          accounts: [process.env.CYPRUS2_PK],
+          chainId: chainId,
         },
         ...more networks
       },
@@ -150,7 +150,7 @@ Hardhat uses a `hardhat.config.js` file to configure smart contract deployments.
 
 </Accordion>
 
-When deploying or verifying a contract, `hardhat.config.js` will pull your private keys and RPC URLs from the `.env` file and use them to deploy and verify your contracts. You can also specify the Solidity version and compiler settings in the `solidity` object.
+When deploying or verifying a contract, `hardhat.config.js` will pull your private keys and RPC URL from the `.env` file and use them to deploy and verify your contracts. You can also specify the Solidity version and compiler settings in the `solidity` object.
 
 ## Deploy and Interact
 
@@ -187,7 +187,7 @@ When deploying or verifying a contract, `hardhat.config.js` will pull your priva
       Your specified network configuration and deployment account is consumed inside of the `provider` and `wallet` variables in tandem with the compiled contract ABI and bytecode to create a new contract instance:
 
       ```js
-      const provider = new quais.JsonRpcProvider(hre.network.config.url)
+      const provider = new quais.JsonRpcProvider(hre.network.config.url, null, { usePathing: true })
       const wallet = new quais.Wallet(hre.network.config.accounts[0], provider)
       const ERC20 = new quais.ContractFactory(ERC20Json.abi, ERC20Json.bytecode, wallet)
       ```
@@ -217,7 +217,34 @@ When deploying or verifying a contract, `hardhat.config.js` will pull your priva
     </Warning>
   </Step>
   <Step title="Interact with the contract">
-    Hardhat console does not currently offer support for interaction with smart contracts on Quai Network. In order to interact with your smart contract, you'll need to utilize the the [client JSON RPC](/build/playground/overview) or [quais.js](https://www.npmjs.com/package/quais) library. You can find examples in the [hardhat-example](https://github.com/dominant-strategies/hardhat-example) repository.
+    Hardhat console does not currently offer support for interaction with smart contracts on Quai Network.
+
+    To interact with the contract, you can configure a simple script using the [Quais SDK](/sdk/static/contract). The script below configures a [Contract](/sdk/content/classes/Contract) instance for the ERC20 token we deployed to `0x00735E9B2c731Fd3eCC8129a3653ACb99dF969cC` to get the name, symbol, and total supply of the token.
+
+    ```javascript getContractDetails.js
+    const quais = require('quais')
+    const ERC20Json = require('../artifacts/contracts/ERC20.sol/TestERC20.json')
+
+    async function getContractDetails() {
+      // Config provider, wallet, and contract factory
+      const provider = new quais.JsonRpcProvider(hre.network.config.url, null, { usePathing: true })
+      const wallet = new quais.Wallet(hre.network.config.accounts[0], provider)
+      const ERC20 = new quais.Contract("0x00735E9B2c731Fd3eCC8129a3653ACb99dF969cC", ERC20Json.abi, wallet)
+
+      const tokenName = await ERC20.name()
+      const tokenSymbol = await ERC20.symbol()
+      const tokenDecimals = await ERC20.decimals()
+      const tokenTotalSupply = await ERC20.totalSupply()
+    }
+
+    getContractDetails()
+      .then(() => process.exit(0))
+      .catch((error) => {
+        console.error(error)
+        process.exit(1)
+      })
+    ```
+
   </Step>
 </Steps>
 

--- a/guides/development/solidityX.mdx
+++ b/guides/development/solidityX.mdx
@@ -64,16 +64,15 @@ Open the `.env` file and add your private keys, RPC URLs, and token args for the
 
 ```bash .env
 # Unique Privkey for each deployment address
-CYPRUS1PK="0x3700000000000000000000000000000000000000000000000000000000000000" # pubkey starting with 0x00
-CYPRUS2PK="0x9400000000000000000000000000000000000000000000000000000000000000" # pubkey starting with 0x01
+CYPRUS1_PK="0x3700000000000000000000000000000000000000000000000000000000000000" # pubkey starting with 0x00
+CYPRUS2_PK="0x9400000000000000000000000000000000000000000000000000000000000000" # pubkey starting with 0x01
 ...more priv keys
 
 # Chain ID (local: 1337, testnet and devnet: 9000)
-CHAINID="9000"
+CHAIN_ID="9000"
 
 # RPC endpoints
-CYPRUS1URL="https://rpc.sandbox.quai.network:9200"
-CYPRUS2URL="https://rpc.sandbox.quai.network:9201"
+RPC_URL="https://rpc.dev.quai.network"
 ...more rpc urls
 
 # Token Arguments
@@ -81,15 +80,15 @@ CYPRUS2URL="https://rpc.sandbox.quai.network:9201"
 ```
 
 <Note>
-The `PRIVKEY` values must all be for unique addresses and correspond to the chain name, i.e. your `CYPRUS1PK` should be the private key of your Cyprus-1 address.
-
-All of the `RPCURL` values have already been filled in for you, but you can change them to your own RPC URLs if you're running your own nodes.
-
+	The `PK` values must all be for unique addresses and correspond to the zone name, i.e. your `CYPRUS1PK` should be the private key of your
+	Cyprus1 address.
 </Note>
 
-Further information on RPC endpoints can be found in the [local network specifications](/build/networks#local-network) section for **local nodes** and the [testnet specifications](/build/networks#testnet) section for **remote nodes**.
+Further information on RPC endpoints can be found in the [local network specifications](/build/networks#local-network) section for **local nodes** and the [devnet specifications](/build/networks#devnet) section for **remote nodes**.
 
-After filling in your private keys, RPC URLs, we're now ready to securely consume them inside of `hardhat.config.js`.
+The `hardhat-example` repository uses the [Quais SDK](/sdk/introduction) to configure network connections using only a single RPC URL. To learn more about how the SDK configures network providers, visit the [SDK provider examples](/sdk/static/provider) section.
+
+After filling in your private keys, RPC URL, we're now ready to securely consume them inside of `hardhat.config.js`.
 
 ### Hardhat Configuration
 
@@ -112,18 +111,21 @@ The below configuration file has **two main differences** from the `hardhat.conf
   const dotenv = require("dotenv");
   dotenv.config({ path: "../.env" });
 
+  const rpcUrl = process.env.RPC_URL;
+  const chainId = Number(process.env.CHAIN_ID);
+
   module.exports = {
     defaultNetwork: "cyprus1",
     networks: {
       cyprus1: {
-        url: `${process.env.CYPRUS1URL}`,
-        accounts: [process.env.CYPRUS1PK],
-        chainId: Number(process.env.CHAINID),
+      url: rpcUrl,
+      accounts: [process.env.CYPRUS1_PK],
+      chainId: chainId,
       },
       cyprus2: {
-        url: `${process.env.CYPRUS2URL}`,
-        accounts: [process.env.CYPRUS2PK],
-        chainId: Number(process.env.CHAINID),
+      url: rpcUrl,
+      accounts: [process.env.CYPRUS2_PK],
+      chainId: chainId,
       },
       ...more networks
     },
@@ -146,7 +148,7 @@ The below configuration file has **two main differences** from the `hardhat.conf
       },
     },
   };
-  ```
+```
   <Warning>
     The Golden Age devnet currently supports Cyprus 1 and 2. All other shards are not running in the current network configuration.
   </Warning>
@@ -199,7 +201,7 @@ To be able to properly compile and deploy SolidityX contracts, we'll need the [S
 
     ```bash
     npx hardhat compile
-    ```
+```
 
     Which should output something like:
 
@@ -208,8 +210,7 @@ To be able to properly compile and deploy SolidityX contracts, we'll need the [S
     Warning: This is a pre-release compiler version, please do not use it in production.
 
     Compiled 2 Solidity files successfully (evm target: istanbul).
-    ```
-
+```
   </Step>
   <Step title="Configure deployment scripts">
     Inside the `scripts/` directory, you'll find a deploy script for both QRC20 and QRC721 contracts: `deployQRC20.js` and `deployQRC721.js`. For this tutorial, we'll be using the QRC721 contract.
@@ -220,15 +221,15 @@ To be able to properly compile and deploy SolidityX contracts, we'll need the [S
 
     ```javascript
     const tokenArgs = [process.env.QRC721_NAME, process.env.QRC721_SYMBOL, process.env.QRC721_BASE_URI]
-    ```
+```
 
     Your specified network configuration is consumed inside of the `provider` and `wallet` variables in tandem with the compiled contract ABI and bytecode to create a new contract instance:
 
     ```javascript
-    const provider = new quais.JsonRpcProvider(hre.network.config.url)
+    const provider = new quais.JsonRpcProvider(hre.network.config.url, null, { usePathing: true })
     const wallet = new quais.Wallet(hre.network.config.accounts[0], provider)
     const QRC721 = new quais.ContractFactory(QRC721Json.abi, QRC721Json.bytecode, wallet)
-    ```
+```
 
     We'll use these ideas to properly modify the token args and network specification to deploy our contracts in the next step.
 
@@ -240,14 +241,14 @@ To be able to properly compile and deploy SolidityX contracts, we'll need the [S
 
     ```bash
     npx hardhat run scripts/deployQRC721.js --network cyprus1
-    ```
+```
 
     Running this should output:
 
     ```bash
     Transaction broadcasted: 0x018100ff42c92c99ddfe8f577ce63743769ae2daf46ad2032eec3bc3f803961d
     Contract deployed to: 0x00735E9B2c731Fd3eCC8129a3653ACb99dF969cC
-    ```
+```
 
     Now, we can deploy an identical QRC721 contract to another shard within Quai, like Cyprus-2. Like before, you'll pass `cyprus2` as the network flag in the deployment command.
 
@@ -258,14 +259,14 @@ To be able to properly compile and deploy SolidityX contracts, we'll need the [S
 
     ```bash
     npx hardhat run scripts/deployQRC721.js --network cyprus2
-    ```
+```
 
     Which again should output something like this:
 
     ```bash
     Transaction broadcasted: 0x01b40095e3d8e9d498a1ee8eb0500b832a3c98abf9b787fcc63a91c37585fbe7
     Contract deployed to: 0x0172F38EC31f58B1419E2CcE2B05B095625218ea
-    ```
+```
 
     We've now deployed our test QRC721 contract to both the Cyprus-1 and Cyprus-2 chains!
 
@@ -283,7 +284,7 @@ _"Linking"_ the two QRC721 contracts can be done by adding the deployed contract
 The `AddApprovedAddresses` method seen below can be used to add as few as 1 or as many as 8 sister contracts to the `approvedAddresses` array of a QRC721 or QRC20 contract.
 
 ```solidity QRC721.sol
-function AddApprovedAddresses(uint8[] calldata chain, address[] calldata addr) external {
+  function AddApprovedAddresses(uint8[] calldata chain, address[] calldata addr) external {
     require(msg.sender == _deployer, "Sender is not deployer");
     require(chain.length == addr.length, "chain and address arrays must be the same length");
     for(uint8 i = 0; i < chain.length; i++) {
@@ -291,7 +292,7 @@ function AddApprovedAddresses(uint8[] calldata chain, address[] calldata addr) e
         require(ApprovedAddresses[chain[i]] == address(0), "The approved address for this zone already exists");
         ApprovedAddresses[chain[i]] = addr[i];
     }
-}
+  }
 ```
 
 Once the sister contract addresses have been added to the respective `ApprovedAddresses` of each of the QRC721 contracts, the cross-chain functionality of the `transferFrom` method becomes available, which allows anyone who owns a token from the collection to trustlessly send their it between shards that the contracts are deployed to.
@@ -311,7 +312,7 @@ const quais = require('quais')
 const QRC721 = require('../artifacts/contracts/QRC721.sol/QRC721.json')
 
 async function AddApprovedQRC721Addresses() {
-	const provider = new quais.JsonRpcProvider(hre.network.config.url)
+	const provider = new quais.JsonRpcProvider(hre.network.config.url, null, { usePathing: true })
 	const privateKey = hre.network.config.accounts[0]
 	const wallet = new quais.Wallet(privateKey, provider)
 	const contractAddress = 'contract address you want to change the address array for' // contract address to add approved addresses to
@@ -319,7 +320,7 @@ async function AddApprovedQRC721Addresses() {
 	try {
 		const tx = await qrc721.AddApprovedAddresses(
 			[0, 1], // chain indexes (cyprus1 is 0, cyprus2 is 1, etc.)
-			['0x1...', '0x2....'] // contract addresses (must be in same order as chain indexes)
+			['0x00...', '0x01....'] // contract addresses (must be in same order as chain indexes)
 		)
 		const txRecipt = await tx.wait()
 		console.log('Transaction mined with hash', txReceipt.hash)
@@ -329,25 +330,20 @@ async function AddApprovedQRC721Addresses() {
 }
 
 AddApprovedQRC721Addresses()
-  .then(() => process.exit(0))
-    .catch((error) => {
-      console.error(error)
-      process.exit(1)
-    })
+	.then(() => process.exit(0))
+	.catch((error) => {
+		console.error(error)
+		process.exit(1)
+	})
 ```
 
 The `addApprovedAddresses.js` script uses the `QRC721.sol` ABI to compose and send a transaction that inserts new addresses to the `approvedAddresses` array in any deployed QRC721 contract.
 
 <Accordion title='How the linking script works'>
 	1. First, creating a quais `provider` with our specified network configuration from Hardhat 
-  2. Creating a quais `wallet` with our
-	`provider` and key config from Hardhat 
-  3. Defining the contract we'd like to add an approved address to with the imported `QRC721.sol`
-	ABI, contract address, and `wallet` 
-  4. Composing the `addApprovedAddresses` transaction with the inputs 
-     - `chainIndex` array: integer chain indices corresponding to the addresses we'd like to add to `approvedAddresses` 
-     - `address` array: the contract addresses that we'd
-	like to add to `approvedAddresses` 
+  2. Creating a quais `wallet` with our `provider` and key config from Hardhat 
+  3. Defining the contract we'd like to add an approved address to with the imported `QRC721.sol` ABI, contract address, and `wallet` 
+  4. Composing the `addApprovedAddresses` transaction with the inputs - `chainIndex` array: integer chain indices corresponding to the addresses we'd like to add to `approvedAddresses` - `address` array: the contract addresses that we'd like to add to `approvedAddresses` 
   5. Sending the transaction and waiting for inclusion in a block.
 </Accordion>
 
@@ -362,7 +358,7 @@ After you've pasted the code for the linking script into the `addApprovedAddress
     ```bash
     Cyprus 1 contract address: 0x00735E9B2c731Fd3eCC8129a3653ACb99dF969cC
     Cyprus 2 contract address: 0x0172F38EC31f58B1419E2CcE2B05B095625218ea
-    ```
+```
 
     We'll take these contract addresses and use them to build the transaction data passed to the `addApprovedAddresses` method.
 
@@ -379,7 +375,7 @@ After you've pasted the code for the linking script into the `addApprovedAddress
     The built transaction should look similar to this:
 
     ```javascript
-    const transactionData = await contract.populateTransaction.AddApprovedAddress(
+    const tx = await qrc721.AddApprovedAddress(
       [0, 1], // chain indexes [cyprus1, cyprus2]
       ['0x00735E9B2c731Fd3eCC8129a3653ACb99dF969cC', '0x0172F38EC31f58B1419E2CcE2B05B095625218ea'] // contract addresses [cyprus1, cyprus2]
     )
@@ -397,20 +393,20 @@ After you've pasted the code for the linking script into the `addApprovedAddress
 
     ```javascript
     const contractAddress = '0x00735E9B2c731Fd3eCC8129a3653ACb99dF969cC'
-    ```
+```
 
     Now, we're ready to run the script and complete the Cyprus 1 contract linkage. Make sure to pass the `--network cyprus1` flag **when sending transactions to the Cyprus 1 contract**.
 
     ```bash
     npx hardhat run scripts/addApprovedAddresses.js --network cyprus1
-    ```
+```
 
     The script should output something like this:
 
     ```bash
     Transaction sent: 0x00499178c3f0046b4d44a57a966f9e224759c1b3158af984fcb5a1432b16ee8e
     Transaction mined with hash: 0x00499178c3f0046b4d44a57a966f9e224759c1b3158af984fcb5a1432b16ee8e
-    ```
+```
 
     We've now linked our Cyprus 1 contract to our Cyprus 2 contract, but we're not done yet.
 
@@ -418,23 +414,21 @@ After you've pasted the code for the linking script into the `addApprovedAddress
 
     ```javascript
     const contractAddress = '0x0172F38EC31f58B1419E2CcE2B05B095625218ea'
-    ```
+```
 
     Lastly, send the linkage transaction to our Cyprus 2 token by running the script with the `--network cyprus2` flag:
 
     ```bash
     Transaction sent: 0x018e8dea20b73089b51e6b3d2b3abd8a9e8ca63e06be20375cf721e13aabd590
     Transaction mined with hash: 0x018e8dea20b73089b51e6b3d2b3abd8a9e8ca63e06be20375cf721e13aabd590
-    ```
+```
 
   </Step>
 </Steps>
 
 Once the second transaction is confirmed, our two QRC721 contracts have been successfully linked across chains. After minting a token, you can now send your NFTs from Cyprus 1 to Cyprus 2 without a bridge or external service!
 
-This deployment and linking process can be repeated for any number of chains within Quai Network purely by deploying the contract to the desired chains and linking them with the `addApprovedAddresses` method. You now have the tools to deploy and link contracts across all 9 shards within Quai Network.
-
-For a more detailed example on how to deploy and link contracts across all shards within Quai Network, check out the [quais-by-example repo](https://github.com/dominant-strategies/quais-by-example/tree/main/contract-qrc721).
+This deployment and linking process can be repeated for any number of chains within Quai Network purely by deploying the contract to the desired chains and linking them with the `addApprovedAddresses` method. You now have the tools to deploy and link contracts across all zone chains within Quai Network.
 
 <Note>
 	The same deploy and link method can be used for any other SolidityX based contract with cross-chain logic, including the [QRC-20

--- a/sdk/introduction.mdx
+++ b/sdk/introduction.mdx
@@ -64,6 +64,7 @@ Quais supports imports in both Node.js and ESM in browser environments.
       import { quais } from "./dist/quais.min.js";
     </script>
     ```
+
   </Tab>
 </Tabs>
 
@@ -77,10 +78,10 @@ As the **Provider** class provides exclusively read-only access to the network, 
 
 ```js
 // Connect a provider to pelagus
-const browserProvider = new quais.BrowserProvider(window.pelagus);
+const browserProvider = new quais.BrowserProvider(window.pelagus)
 
 // Connect a provider to a remote node
-const provider = new quais.JsonRpcProvider('https://rpc.sandbox.quai.network');
+const provider = new quais.JsonRpcProvider('https://rpc.dev.quai.network', null, { usePathing: true })
 ```
 
 ### Transaction
@@ -94,26 +95,24 @@ Transactions within Quai generally serve 4 different purposes: sending tokens fr
 ```js
 // Create a transaction
 const tx = {
-  to: '0x1234567890123456789012345678901234567890',
-  value: parseQuai('1.0'),
+	to: '0x1234567890123456789012345678901234567890',
+	value: parseQuai('1.0'),
 }
 
 // Send a transaction
-await signer.sendTransaction(tx);
+await signer.sendTransaction(tx)
 ```
 
 ### Contract
 
-A [Contract](/sdk/content/classes/Contract) is a piece of code that has been deployed to and stored on the Quai ledger virtual machine. They do not exist on the Qi ledger. 
+A [Contract](/sdk/content/classes/Contract) is a piece of code that has been deployed to and stored on the Quai ledger virtual machine. They do not exist on the Qi ledger.
 
 Contract state changing operations can be executed using a [Signer](/sdk/content/interfaces/Signer) and data can be from them using a [Provider](/sdk/content/interfaces/Provider).
 
 ```js
 // create a contract
-const contract = new quais.Contract(contractAddress, contractABI, provider);
+const contract = new quais.Contract(contractAddress, contractABI, provider)
 
 // call a read-only contract function
-const symbol = await contract.symbol();
+const symbol = await contract.symbol()
 ```
-
-

--- a/sdk/static/contract.mdx
+++ b/sdk/static/contract.mdx
@@ -21,7 +21,7 @@ In order to interact with a contract in any read-only capacity, you must "connec
 
 ```js
 // set up a remote node provider
-const provider = new quais.JsonRpcProvider('https://rpc.sandbox.quai.network')
+const provider = new quais.JsonRpcProvider('https://rpc.dev.quai.network', null, { usePathing: true })
 
 // connect to the contract using the provider
 const contract = new quais.Contract(contractAddress, contractABI, provider)
@@ -45,7 +45,7 @@ If you want to execute a contract state-changing operation, you'll need to pass 
 
 ```js
 // get signer from pelagus provider
-const provider = new quais.JsonRpcProvider(window.pelagus)
+const provider = new quais.BrowserProvider(window.pelagus)
 const signer = provider.getSigner()
 
 // connect the signer to the contract

--- a/sdk/static/examples/send-transaction.mdx
+++ b/sdk/static/examples/send-transaction.mdx
@@ -10,7 +10,7 @@ description: Sign and send transactions on the Quai and Qi ledgers.
         To send a Quai transaction, you'll first need to connect a [Wallet](/sdk/content/classes/Wallet) or [QuaiHDWallet](/sdk/content/classes/QuaiHDWallet) to a [Provider](/sdk/content/interfaces/Provider).
 
         ```js
-        const provider = new quais.JsonRpcProvider('https://rpc.sandbox.quai.network')
+        const provider = new quais.JsonRpcProvider('https://rpc.dev.quai.network', null, { usePathing: true })
 
         // initialize wallet
         const wallet = new quais.Wallet(privateKey, provider)
@@ -65,7 +65,7 @@ description: Sign and send transactions on the Quai and Qi ledgers.
         To send a Qi transaction, you'll first need to connect a [QiHDWallet](/sdk/content/classes/QiHDWallet) to a [Provider](/sdk/content/interfaces/Provider) and sync the UTXO set.
 
         ```js
-        const provider = new quais.JsonRpcProvider('https://rpc.sandbox.quai.network')
+        const provider = new quais.JsonRpcProvider('https://rpc.dev.quai.network', null, { usePathing: true })
 
         // initialize HD wallet
         const hdWallet = quais.QiHDWallet.fromMnemonic(mnemonic)

--- a/sdk/static/examples/wallet-management.mdx
+++ b/sdk/static/examples/wallet-management.mdx
@@ -80,7 +80,7 @@ description: Manage Qi and Quai HD wallets.
     const phrase = 'pill tomorrow foster begin walnut borrow virtual kick shift mutual shoe scatter'
 
     // initialize provider
-    const provider = new quais.JsonRpcProvider('https://rpc.sandbox.quai.network')
+    const provider = new quais.JsonRpcProvider('https://rpc.dev.quai.network', null, { usePathing: true })
 
     // initialize HD wallet from mnemonic
     const mnemonic = quais.Mnemonic.fromPhrase(phrase)

--- a/sdk/static/provider.mdx
+++ b/sdk/static/provider.mdx
@@ -14,9 +14,33 @@ Providers are one of the most fundamental components of interacting with a block
 ## Usage
 
 There are two types of network providers you can connect to:
-- **Browser/Injected Providers**: typically wallet interfaces used in browser Applications
-- **Remote Node Providers**: any remote node that is open to data requests
 
+- **Remote Node Providers**: any remote node that is open to data requests
+- **Browser/Injected Providers**: typically wallet interfaces used in browser Applications
+
+### Remote Node Provider
+
+To connect to a remote node provider, use the [JsonRpcProvider](/sdk/content/classes/JsonRpcProvider) or [WebSocketProvider](/sdk/content/classes/WebSocketProvider) classes. This connects to a remote node using the JSON-RPC interface. **Remote node providers will never have a signer bundled into them**.
+
+Quais providers are configured to first ask the node which shards it is currently running, and then establish a connection to each of those chains. This is done using one of two ways:
+
+- Using the standard [go-quai node port mapping](/build/networks#networking-information)
+  - Available using the Sandbox RPC endpoint with `http` and `ws`
+- Via [reverse proxy pathing](https://github.com/dominant-strategies/quai-nginx)
+  - Available using the Dev RPC endpoint with `https` and `wss`
+
+```js
+import { quais } from 'quais'
+
+// configure a multi-shard JSON-RPC provider using the sandbox rpc and port mapping
+const provider = new quais.JsonRpcProvider('http://rpc.sandbox.quai.network')
+
+// configure a multi-shard JSON-RPC provider using the dev rpc and pathing
+const provider = new quais.JsonRpcProvider('https://rpc.dev.quai.network', null, { usePathing: true })
+
+// configure a multi-shard WebSocket provider using the dev rpc and pathing
+const provider = new quais.WebSocketProvider('wss://rpc.dev.quai.network', null, { usePathing: true })
+```
 
 ### Injected Provider
 
@@ -32,17 +56,4 @@ const provider = new quais.BrowserProvider(window.pelagus)
 
 // get the signer
 const signer = provider.getSigner()
-```
-
-### Remote Node Provider
-
-To connect to a remote node provider, use the [JsonRpcProvider](/sdk/content/classes/JsonRpcProvider) class. This connects to a remote node using the JSON-RPC interface. **Remote node providers will never have a signer bundled into them**.
-
-Remote providers generally provide a connection to all chains within the network. Once a provider is configured, any data passed to it will be interpretted by the provider and routed to the correct chain automatically by the SDK.
-
-```js
-import { quais } from 'quais'
-
-// configure a remote node provider
-const provider = new quais.JsonRpcProvider('https://rpc.sandbox.quai.network')
 ```


### PR DESCRIPTION
- Update network specifications for RPC endpoints to pathed endpoints
- Add websocket port mapping to local network spec
- Update all instances of `quais.JsonRpcProvider()` and `quais.WebsocketProvider()` to handle pathing/port mapping
- Update a few out of date links

TODO:
- Update development tutorials to match hardhat upgrades that come with provider updates