### PR TITLE
Fix links for miner guides

### DIFF
--- a/guides/miner/hiveos-flight-sheet.mdx
+++ b/guides/miner/hiveos-flight-sheet.mdx
@@ -96,7 +96,7 @@ To start the Flight Sheet installation, open up your [HiveOS Farm Dashboard](htt
     Click "add flight sheet". Fill out the flight sheet information:
 
     - For the **Miner name**, type "quai_custom".
-    - For the **Installation URL**, copy the [Quai Flight Sheet URL](https://github.com/dominant-strategies/quai-gpu-miner/releases/download/v0.1.0/quai-gpu-miner.tar.gz).
+    - For the **Installation URL**, copy the [Quai Flight Sheet URL](https://github.com/dominant-strategies/quai-gpu-miner/releases/download/v0.2.0/quai-gpu-miner-v0.2.0.tar.gz).
     - For the **Hash algorithm**, type "progpow".
     - For the **Wallet and worker template**, type "%WAL%.%WORKER_NAME%".
     - For the **Pool URL**, type "stratum://EXTERNALIPADDRESS:PORT".

--- a/guides/miner/hiveos.mdx
+++ b/guides/miner/hiveos.mdx
@@ -105,7 +105,7 @@ Once you've installed and set up HiveOS on your rig, you'll need to update drive
 Now that all of our dependencies are installed, we can install quai-gpu-miner. There are two options for installation:
 
 - Install [pre-compiled binaries](https://github.com/dominant-strategies/quai-gpu-miner/releases)
-- Compile and install from source via [automated script](https://github.com/dominant-strategies/quai-gpu-miner/blob/main/miner_deploy.sh)
+- Compile and install from source via [automated script](https://github.com/dominant-strategies/quai-gpu-miner/blob/main/deploy_miner.sh)
 
 <Tabs>
   <Tab title="Pre-compiled Binaries">
@@ -133,7 +133,7 @@ Now that all of our dependencies are installed, we can install quai-gpu-miner. T
       Compiling from source may take a while to complete, and will require about 10gb of RAM. If your machine does not have the required RAM, it is recommend to install via pre-compiled binaries.
     </Warning>
 
-     The [quai-gpu-miner](https://github.com/dominant-strategies/quai-gpu-miner) repository contains a [automated script](https://github.com/dominant-strategies/quai-gpu-miner/blob/main/miner_deploy.sh) that can be used to compile and configure the miner. The `deploy_miner.sh` script will install the following build dependencies and build the latest version of the miner:
+     The [quai-gpu-miner](https://github.com/dominant-strategies/quai-gpu-miner) repository contains a [automated script](https://github.com/dominant-strategies/quai-gpu-miner/blob/main/deploy_miner.sh) that can be used to compile and configure the miner. The `deploy_miner.sh` script will install the following build dependencies and build the latest version of the miner:
 
      - git
      - cmake

--- a/guides/miner/ubuntu.mdx
+++ b/guides/miner/ubuntu.mdx
@@ -60,7 +60,7 @@ For this tutorial, you'll need an Ubuntu machine. Instructions on how to downloa
 
 Start by installing the GPU Miner at the root directory. There is a single installation option for Ubuntu machines:
 
-- Compile and install from source via [automated script](https://github.com/dominant-strategies/quai-gpu-miner/blob/main/miner_deploy.sh)
+- Compile and install from source via [automated script](https://github.com/dominant-strategies/quai-gpu-miner/blob/main/deploy_miner.sh)
 
 The [quai-gpu-miner](https://github.com/dominant-strategies/quai-gpu-miner) repository contains a [automated script](https://github.com/dominant-strategies/quai-gpu-miner/blob/main/deploy_miner.sh) that can be used to compile and build the miner. The `deploy_miner.sh` script will install the following build dependencies and build the latest version of the miner:
 


### PR DESCRIPTION
Fix flight sheet and `deploy_miner.sh` script links