### PR TITLE
Create access list fix + Quai coinbase spec

### DIFF
--- a/api-reference/openapi-spec/transactions/openapi-createAccessList.json
+++ b/api-reference/openapi-spec/transactions/openapi-createAccessList.json
@@ -12,7 +12,7 @@
 	"paths": {
 		"/": {
 			"post": {
-				"summary": "quai_call",
+				"summary": "quai_createAccessList",
 				"description": "Creates an access list for the provided transaction.",
 				"requestBody": {
 					"required": true,
@@ -53,8 +53,8 @@
 					"method": {
 						"type": "string",
 						"description": "The name of the method to be invoked.",
-						"example": "quai_call",
-						"enum": ["quai_call"]
+						"example": "quai_createAccessList",
+						"enum": ["quai_createAccessList"]
 					},
 					"params": {
 						"type": "array",

--- a/guides/client/node.mdx
+++ b/guides/client/node.mdx
@@ -226,7 +226,10 @@ There are a few key variables required to run a Quai node. **They will be passed
 
   </Step>
   <Step title="Reward Lockup Period">
-    The Quai protocol immediately pays out block rewards as blocks are mined, but are subject to a lockup period. Block reward tokens are sent to the coinbase of the miner and register as balance, but are deemed "not spendable" until they are unlocked.
+    The Quai protocol immediately pays out block rewards as blocks are mined, but are subject to a lockup period. 
+  
+    - Quai Block rewards are sent to the coinbase of the miner after the lockup period has elapsed.
+    - Qi Block reward tokens are sent to the coinbase of the miner and register as balance, but are deemed "not spendable" until they are unlocked.
 
     The lockup period is configurable by miners using the `--node.coinbase-lockup` flag. The protocol provides additional incentives for miners to lock up their block rewards for a longer period of time.
 


### PR DESCRIPTION
- Update typo in `quai_createAccessList`
- Add specification for the behavior of Quai coinbase reward payouts after lock period.