### PR TITLE
Remove orchard network specs

### DIFF
--- a/build/networks.mdx
+++ b/build/networks.mdx
@@ -48,17 +48,14 @@ The Quai Network testnet is named `colosseum` as it's where network upgrades go 
 
 ## Devnet
 
-<Tip>
-  The public developer network is currently running the **Golden Age Testnet** version of the Quai Protocol, compatible with [quais v1.0.0-alpha.8](https://www.npmjs.com/package/quais) and later.
-  This network is designed for developers to test features and **has no incentives**.
+<Warning>
+  The public developer network is not currently live.
 
-</Tip>
+</Warning>
 
 Devnet is a public isolated development environment that is designed to be used by both smart contract and tooling developers to test smart-contract deployments and infrastructure upgrades in a production-like environment.
 
 QUAI on the devnet has no real value and thus testing deployments, interactions, and smart contracts are virtually free. As devnet QUAI has no value, there are _no markets_ to purchase devnet tokens.
-
-**The devnet is currently accesible by developers via the RPC endpoints below, but will remain closed to local node connections and miners**.
 
 ### Network Specifications
 
@@ -79,14 +76,7 @@ QUAI on the devnet has no real value and thus testing deployments, interactions,
 
 #### Explorer URLs and RPC Endpoints
 
-<Info>
-	More detailed specifications for **port to shard** and **URL path to shard** mappings can be found in the [quai-nginx
-	repository](https://github.com/dominant-strategies/quai-nginx).
-</Info>
-
-| Zone Name | Zone Index | Explorer URL | RPC Endpoint (https)                     | RPC Endpoint (wss)                     |
-| --------- | ---------- | ------------ | ---------------------------------------- | -------------------------------------- |
-| cyprus1   | [0 0]      | N/A          | https://rpc.orchard.quai.network/cyprus1 | wss://rpc.orchard.quai.network/cyprus1 |
+<Warning>No public explorers or RPC endpoints are currently available for the devnet.</Warning>
 
 ## Local Network
 


### PR DESCRIPTION
Take down Orchard specs from networks page as it is not live.